### PR TITLE
Temp fix for Compose <-> Kapt issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,10 +23,6 @@ android {
         buildConfigField("String", "API_KEY", apikeyProperties['API_KEY'])
         buildConfigField("String", "PRIVATE_KEY", apikeyProperties['PRIVATE_KEY'])
     }
-//    buildFeatures {
-//        // Enables Jetpack Compose for this module
-//        compose true
-//    }
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
Using some libraries that depend on kapt along with Jetpack compose causes build issues
```
Caused by: java.lang.AssertionError: IR backend shouldn't call KotlinTypeMapper.mapType: BaseViewModel
    at org.jetbrains.kotlin.codegen.state.KotlinTypeMapper.mapType(KotlinTypeMapper.kt:261)
    at org.jetbrains.kotlin.codegen.state.KotlinTypeMapper.mapClass(KotlinTypeMapper.kt:222)
    at org.jetbrains.kotlin.codegen.MemberCodegen.genClassOrObject(MemberCodegen.java:297)
    at org.jetbrains.kotlin.codegen.MemberCodegen.genClassOrObject(MemberCodegen.java:286)
    at org.jetbrains.kotlin.codegen.PackageCodegenImpl.generateClassesAndObjectsInFile(PackageCodegenImpl.java:118)
    at org.jetbrains.kotlin.codegen.PackageCodegenImpl.generateFile(PackageCodegenImpl.java:137)
    at org.jetbrains.kotlin.codegen.PackageCodegenImpl.generate(PackageCodegenImpl.java:68)
    ... 46 more
```

The issue is due to using the IR backend which compose implicitly uses. More details in this jetbrains ticket - https://youtrack.jetbrains.com/issue/KT-34583

As a temp fix, I removed the following lines which causes some instability to compose(however it still works). I think it's good enough for our case hopefully and should allow us to continue development. 
```
buildFeatures {
        // Enables Jetpack Compose for this module
        compose true
    }
```

If you face any issues whatsoever, we can revert my compose related PR's. Let me know!